### PR TITLE
Ввод года рождения для игроков, у которых он не заполнен

### DIFF
--- a/players/addPlayerMenu.js
+++ b/players/addPlayerMenu.js
@@ -68,6 +68,14 @@ export default class AddPlayerMenu {
             when: answers => typeof answers.addPlayer === 'string' && answers.addPlayer !== 'back' && answers.addPlayer !== 'quit'
         },
         {
+            type: 'input',
+            name: 'newBirthYear',
+            message: 'Год рождения (не указан у игрока)',
+            when: answers => typeof answers.addPlayer === 'object' && answers.addPlayer != null
+                && !answers.addPlayer.birthYear
+                && answers.addPlayer !== 'back' && answers.addPlayer !== 'quit'
+        },
+        {
             type: 'list',
             name: 'confirmSwitchTeam',
             message: answers => `Игрок уже числится в составе команды ${answers.addPlayer.teamName}. Точно перевести в команду ${answers.newPlayer.teamName}`,
@@ -125,6 +133,7 @@ export default class AddPlayerMenu {
             answers.addPlayer
                 ? this.playersService.editPlayer({
                     ...answers.addPlayer,
+                    ...(answers.newBirthYear !== undefined && answers.newBirthYear !== '' ? { birthYear: answers.newBirthYear } : {}),
                     team: answers.team.id,
                     tournaments: answers.addPlayer.tournaments || [],
                 }).then(() => answers.addPlayer)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized CLI/data-update change that only conditionally sets `birthYear` on existing players; low risk aside from potential input validation/format issues.
> 
> **Overview**
> Adds an extra CLI prompt in `players/addPlayerMenu.js` to collect `birthYear` when selecting an existing player who doesn’t have it filled.
> 
> When editing an existing player during add-to-team, the entered value is conditionally merged into the `editPlayer` payload (ignored if left empty), so missing birth years can be backfilled without affecting players that already have one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c93b4da5f4a54a95a1aa61871d07d0f84ae9dce4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->